### PR TITLE
Repo audit uploader

### DIFF
--- a/src/codebase_dump/app.py
+++ b/src/codebase_dump/app.py
@@ -4,7 +4,9 @@ import os
 
 from codebase_dump.core.ignore_patterns_manager import IgnorePatternManager
 from codebase_dump.core.codebase_analysis import CodebaseAnalysis
+from codebase_dump.core.audit_api_uploader import AuditApiUploader
 from codebase_dump.core.output_formatter import OutputFormatterBase, MarkdownOutputFormatter, PlainTextOutputFormatter
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -15,6 +17,7 @@ def main():
     parser.add_argument("--max-size", type=int, default=10240, help="Maximum allowed text content size in KB (default: 10240 KB)")
     parser.add_argument("-o", "--output-format", choices=["text", "markdown"], default="text", help="Output format (default: text)")
     parser.add_argument("-f", "--file", help="Output file name (default: <directory_name>_codebase_dump.<format_extension>)")
+    parser.add_argument("--audit-upload", help="Send the output to the audits API", action="store_true")
     
     if len(sys.argv) == 1:
         parser.print_help(sys.stderr)
@@ -65,6 +68,15 @@ def main():
     print("Analysis Summary\n")
     print(output_formatter.generate_tree_string(data))
     print(output_formatter.generate_summary_string(data))
+
+    if args.audit_upload:
+        print("Uploading to audits API...")
+        audit_api_uploader = AuditApiUploader(
+            api_key="XXXXXX",
+            api_url="https://repo-analysis-app.vercel.app/api/repo/add"
+        )
+        audit_api_uploader.upload_audit(output)
+        print("Upload complete.")
 
 if __name__ == "__main__":
     main()

--- a/src/codebase_dump/core/audit_api_uploader.py
+++ b/src/codebase_dump/core/audit_api_uploader.py
@@ -1,0 +1,29 @@
+import json
+import requests
+
+class AuditApiUploader:
+    def __init__(self, api_key, api_url):
+        self.api_key = api_key
+        self.api_url = api_url
+        if not self.api_key:
+            raise ValueError("API Key is required to upload audit")
+        
+    def upload_audit(self, audit: str):
+        if not audit:
+            raise ValueError("Repo content is required to upload")
+        
+        headers = {
+            "x-api-key": self.api_key,
+        }
+        payload = {
+            "text": audit
+        }
+
+        response = requests.post(self.api_url, 
+                                 json=payload,
+                                 headers=headers)
+        if response.status_code != 200:
+            raise ValueError(f"Failed to upload audit: {response.text}")
+        
+        print("Audit uploaded successfully")
+        print(f"Audit ID: {response.text}")

--- a/src/codebase_dump/core/output_formatter.py
+++ b/src/codebase_dump/core/output_formatter.py
@@ -65,7 +65,7 @@ class PlainTextOutputFormatter(OutputFormatterBase):
         return ".txt"
     
     def format(self, data: DirectoryAnalysis) -> str:
-        output = f"Codebase Analysis for: {data.name}\n"
+        output = f"Codebase dump for the project: {data.name}\n"
         output += "\nDirectory Structure:\n"
         output += self.generate_tree_string(data, show_size=True, show_ignored=True)
         output += self.generate_summary_string(data)
@@ -83,7 +83,7 @@ class MarkdownOutputFormatter(OutputFormatterBase):
         return ".md"
     
     def format(self, data: DirectoryAnalysis) -> str:
-        output = f"# Codebase Analysis for: {data.name}\n\n"
+        output = f"# Codebase dump for the project: {data.name}\n\n"
         output += "## Directory Structure\n\n"
         output += "```\n"
         output += self.generate_tree_string(data, show_size=True, show_ignored=True)

--- a/tests/test_audit_api_uploader.py
+++ b/tests/test_audit_api_uploader.py
@@ -1,0 +1,73 @@
+import unittest
+from codebase_dump.core.audit_api_uploader import AuditApiUploader
+from unittest.mock import patch, MagicMock
+from io import StringIO
+import sys
+
+class TestAuditApiUploader(unittest.TestCase):
+    def test_init_no_api_key(self):
+        """Test that initializing without an API key raises ValueError."""
+        with self.assertRaises(ValueError) as context:
+            AuditApiUploader(api_key="", api_url="http://example.com/upload")
+
+        self.assertIn("API Key is required", str(context.exception))
+
+    def test_upload_no_audit_text(self):
+        """Test that uploading without audit text raises ValueError."""
+        uploader = AuditApiUploader(api_key="test_key", api_url="http://example.com/upload")
+        with self.assertRaises(ValueError) as context:
+            uploader.upload_audit(audit="")
+        self.assertIn("Repo content is required", str(context.exception))
+
+    @patch('requests.post')
+    def test_upload_success(self, mock_post):
+        """Test a successful upload."""
+        # Setup mock response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "12345"
+        mock_post.return_value = mock_response
+
+        uploader = AuditApiUploader(api_key="test_key", api_url="http://example.com/upload")
+        
+        # Capture stdout to verify print statements
+        captured_output = StringIO()
+        sys.stdout = captured_output
+
+        uploader.upload_audit(audit="This is a test audit.")
+        
+        # Restore stdout
+        sys.stdout = sys.__stdout__
+
+        # Verify requests.post call
+        mock_post.assert_called_once_with(
+            "http://example.com/upload",
+            json={"text": "This is a test audit."},
+            headers={"x-api-key": "test_key"}
+        )
+
+        # Check output content
+        output = captured_output.getvalue()
+        self.assertIn("Audit uploaded successfully", output)
+        self.assertIn("Audit ID: 12345", output)
+
+    @patch('requests.post')
+    def test_upload_failure(self, mock_post):
+        """Test a failure scenario where the server returns non-200 status."""
+        # Setup mock response to fail
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Error uploading"
+        mock_post.return_value = mock_response
+
+        uploader = AuditApiUploader(api_key="test_key", api_url="http://example.com/upload")
+        
+        with self.assertRaises(ValueError) as context:
+            uploader.upload_audit(audit="Test audit.")
+        
+        self.assertIn("Failed to upload audit: Error uploading", str(context.exception))
+        mock_post.assert_called_once_with(
+            "http://example.com/upload",
+            json={"text": "Test audit."},
+            headers={"x-api-key": "test_key"}
+        )


### PR DESCRIPTION
Repo dump can be now uploaded to https://repo-analysis-app.vercel.app/ so it's possible to run some audits immediately.